### PR TITLE
Initializing date picker with new Date() when model value is empty.

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -21,10 +21,10 @@ angular.module('mdDateTime', [])
 		attrs.$observe 'maxdate', (val) ->
 			if val? and angular.isDate val then scope.restrictions.maxdate = val
 		ngModel.$render = -> scope.setDate ngModel.$modelValue
-		
+
 		saveFn = $parse attrs.onSave
 		cancelFn = $parse attrs.onCancel
-		
+
 		scope.save = ->
 			scope._modelValue = scope.date
 			ngModel.$setDirty()
@@ -37,7 +37,7 @@ angular.module('mdDateTime', [])
 			mindate: undefined
 			maxdate: undefined
 		scope.setDate = (newVal) ->
-			scope.date = if newVal? then new Date newVal else new Date()
+			scope.date = if newVal then new Date newVal else new Date()
 			scope.calendar._year = scope.date.getFullYear()
 			scope.calendar._month = scope.date.getMonth()
 			scope.clock._minutes = scope.date.getMinutes()


### PR DESCRIPTION
In some cases model value connected to date picker is empty and then we can see sth like this:

![image](https://cloud.githubusercontent.com/assets/7491025/7356825/09b3f85a-ed2b-11e4-876b-11d1901e0859.png)

This is fixing the issue.
